### PR TITLE
Fix up the output of mysqld_safe --wsrep-recover

### DIFF
--- a/mariadb-10.1.18-revert-stdouterr-closing.patch
+++ b/mariadb-10.1.18-revert-stdouterr-closing.patch
@@ -1,0 +1,35 @@
+diff -up mariadb-10.1.18/scripts/mysqld_safe.sh.revert mariadb-10.1.18/scripts/mysqld_safe.sh
+--- mariadb-10.1.18/scripts/mysqld_safe.sh.revert	2016-11-03 11:29:24.303905985 +0100
++++ mariadb-10.1.18/scripts/mysqld_safe.sh	2016-11-03 11:30:55.431325156 +0100
+@@ -738,10 +738,6 @@ else
+   logging=syslog
+ fi
+ 
+-# close stdout and stderr, everything goes to $logging now
+-exec 1>&-
+-exec 2>&-
+-
+ USER_OPTION=""
+ if test -w / -o "$USER" = "root"
+ then
+@@ -772,7 +768,7 @@ if [ ! -d $mysql_unix_port_dir ]
+ then
+   if ! `mkdir -p $mysql_unix_port_dir`
+   then
+-    log_error "Fatal error Can't create database directory '$mysql_unix_port'"
++    echo "Fatal error Can't create database directory '$mysql_unix_port'"
+     exit 1
+   fi
+   chown $user $mysql_unix_port_dir
+diff -up mariadb-10.1.18/support-files/mysql.server.sh.revert mariadb-10.1.18/support-files/mysql.server.sh
+--- mariadb-10.1.18/support-files/mysql.server.sh.revert	2016-11-03 11:29:51.698031995 +0100
++++ mariadb-10.1.18/support-files/mysql.server.sh	2016-11-03 11:33:14.795966211 +0100
+@@ -308,7 +308,7 @@ case "$mode" in
+     then
+       # Give extra arguments to mysqld with the my.cnf file. This script
+       # may be overwritten at next upgrade.
+-      $bindir/mysqld_safe --datadir="$datadir" --pid-file="$mysqld_pid_file_path" "$@" &
++      $bindir/mysqld_safe --datadir="$datadir" --pid-file="$mysqld_pid_file_path" "$@" >dev/null &
+       wait_for_ready; return_value=$?
+ 
+       # Make lock for RedHat / SuSE

--- a/mariadb.spec
+++ b/mariadb.spec
@@ -123,7 +123,7 @@
 
 Name:             mariadb
 Version:          %{compatver}.%{bugfixver}
-Release:          1%{?with_debug:.debug}%{?dist}
+Release:          2%{?with_debug:.debug}%{?dist}
 Epoch:            3
 
 Summary:          A community developed branch of MySQL
@@ -175,6 +175,11 @@ Patch31:          %{pkgnamepatch}-string-overflow.patch
 Patch32:          %{pkgnamepatch}-basedir.patch
 Patch34:          %{pkgnamepatch}-covscan-stroverflow.patch
 Patch37:          %{pkgnamepatch}-notestdb.patch
+# Due to LP https://bugs.launchpad.net/tripleo/+bug/1638864
+# Reverts 7497ebf8a49bfe30bb4110f2ac20a30f804b7946 until we fix the
+# galera resource agent to cope with this change
+# When RHBZ#1391470 gets fixed and released in centos we can remove this patch
+Patch38:          %{pkgnamepatch}-10.1.18-revert-stdouterr-closing.patch
 
 # Patches for galera
 Patch40:          %{pkgnamepatch}-galera.cnf.patch
@@ -1301,6 +1306,10 @@ fi
 %endif
 
 %changelog
+* Thu Nov 03 2016 Michele Baldessari <michele@acksyn.org> - 3:10.1.18-2
+- Back out upstream commit 7497ebf8a49bfe30bb4110f2ac20a30f804b7946 as it
+  breaks the resource agent
+
 * Tue Oct  4 2016 Jakub Dorňák <jdornak@redhat.com> - 3:10.1.18-1
 - Update to 10.1.18
 


### PR DESCRIPTION
Via LP https://bugs.launchpad.net/tripleo/+bug/1638864 we discovered
that the upstream change "mysqld_safe: close stdout and stderr"
7497ebf8a49bfe30bb4110f2ac20a30f804b7946 broke the galera resource
agent. The fix for the resource agent is tracked in BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1391470
Once that gets fixed we can remove this revert.

Damien and I tested the package with this revert included
and galera could start correctly.