### PR TITLE
Bump mariadb version to the intended value (10.1.20)

### DIFF
--- a/mariadb.spec
+++ b/mariadb.spec
@@ -119,8 +119,8 @@
 
 # Make long macros shorter
 %global sameevr   %{epoch}:%{version}-%{release}
-%global compatver 10.0
-%global bugfixver 28
+%global compatver 10.1
+%global bugfixver 20
 
 Name:             mariadb
 Version:          %{compatver}.%{bugfixver}


### PR DESCRIPTION
During review of commit  45cb8f2073e6120cc0339ef3f7958ad0465b8a99 we inadvertently let a bad version number for mariadb sneak in specfile. This PR fixes it.