### PR TITLE
Do not depend on mysql-selinux, use selinux-policy-targeted instead

### DIFF
--- a/mariadb.spec
+++ b/mariadb.spec
@@ -16,7 +16,7 @@
 %global force_run_testsuite 0
 
 # Aditional SELinux rules
-%global require_mysql_selinux 1
+%global require_mysql_selinux 0
 
 # In f20+ use unversioned docdirs, otherwise the old versioned one
 %global _pkgdocdirname %{pkg_name}%{!?_pkgdocdir:-%{version}}
@@ -152,7 +152,7 @@
 
 Name:             mariadb
 Version:          10.3.20
-Release:          3%{?with_debug:.debug}%{?dist}.0.0.rdo0
+Release:          3%{?with_debug:.debug}%{?dist}.0.0.rdo1
 Epoch:            3
 
 Summary:          A very fast and robust SQL database server
@@ -1628,6 +1628,9 @@ fi
 %endif
 
 %changelog
+* Tue Feb 11 2020 Damien Ciabrini <dciabrin@redhat.com> - 10.3.20-3.0.0.rdo1
+- Do not depend on mysql-selinux, use selinux-policy-targeted instead
+
 * Mon Dec 23 2019 Damien Ciabrini <dciabrin@redhat.com> - 10.3.20-3.0.0.rdo0
 - Rebase to version 10.3.20 from Fedora 31
 - Keep extra SST method wsrep_sst_rsync_tunnel


### PR DESCRIPTION
Disable requirement of mysql-selinux, otherwise the generated
mariadb rpms cannot be installed with the base packages that we
consume in RDO.

Tested by building a mariadb kolla image with kolla build:
# docker run -it localhost:5000/tripleoupstream/centos-binary-mariadb:9.1.0 bash
()[mysql@3e7fac385719 /]$ rpm -qa mariadb\*
mariadb-libs-10.3.20-3.el7.0.0.rdo1.x86_64
mariadb-server-galera-10.3.20-3.el7.0.0.rdo1.x86_64
mariadb-errmsg-10.3.20-3.el7.0.0.rdo1.x86_64
mariadb-10.3.20-3.el7.0.0.rdo1.x86_64
mariadb-config-10.3.20-3.el7.0.0.rdo1.x86_64
mariadb-server-10.3.20-3.el7.0.0.rdo1.x86_64
mariadb-server-utils-10.3.20-3.el7.0.0.rdo1.x86_64
mariadb-common-10.3.20-3.el7.0.0.rdo1.x86_64
mariadb-backup-10.3.20-3.el7.0.0.rdo1.x86_64
